### PR TITLE
chore: update depn & fix path for core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-local-ai",
-  "version": "1.0.0-beta.51",
+  "version": "1.0.0-beta.52",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "dependencies": {
-    "@elizaos/core": "^1.0.0-beta.51",
+    "@elizaos/core": "^1.0.0-beta.57",
     "@huggingface/hub": "^1.1.2",
     "@huggingface/inference": "^3.13.0",
     "@huggingface/transformers": "^3.5.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "moduleDetection": "force",
     "allowArbitraryExtensions": true,
     "paths": {
-      "@elizaos/core": ["../core/src"],
-      "@elizaos/core/*": ["../core/src/*"]
+      "@elizaos/core": ["../../core/src"],
+      "@elizaos/core/*": ["../../core/src/*"]
     }
   },
   "include": ["src/**/*.ts"]

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,8 +6,9 @@ export default defineConfig({
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   sourcemap: true,
   clean: true,
-  format: ['esm'], // Ensure you're targeting CommonJS
+  format: ['esm'],
   dts: true,
+  noExternal: ['eventemitter3', 'ipull'], // Bundle problematic packages
   external: [
     'dotenv', // Externalize dotenv to prevent bundling
     'fs', // Externalize fs to use Node.js built-in module


### PR DESCRIPTION
Update depn, path in tsup and fix the issue with package load. 

```
nts/test-cli-beta-v2/myapp/node_modules/@elizaos/plugin-local-ai/dist/index.js'):
    message: "(SyntaxError) Named export 'EventEmitter' not found. The requested module 'eventemitter3' is a CommonJS module, which may not support all module.exports as named exports.\nCommonJS modules can always be imported via the default export, for example using:\n\nimport pkg from 'eventemitter3';\nconst { EventEmitter } = pkg;\n"
    stack: [
      "file:///Users/[username]/[project-path]/test-cli-beta-v2/myapp/node_modules/ipull/dist/download/download-engine/download-file/download-engine-file.js:3",
      "import { EventEmitter } from \"eventemitter3\";",
      "^^^^^^^^^^^^",
      "SyntaxError: Named export 'EventEmitter' not found. The requested module 'eventemitter3' is a CommonJS module, which may not support all module.exports as named exports.",
      "CommonJS modules can always be imported via the default export, for example using:",
      "",
      "import pkg from 'eventemitter3';",
      "const { EventEmitter } = pkg;",
      "",
      "at ModuleJob._instantiate (node:internal/modules/esm/module_job:182:21)",
      "at async ModuleJob.run (node:internal/modules/esm/module_job:266:5)",
      "at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)",
      "at async tryImporting (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-YBZJYETY.js:11473:20)",
      "at async loadPluginModule (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-YBZJYETY.js:11531:20)",
      "at async verifyPluginImport (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-YBZJYETY.js:11875:24)",
      "at async attemptInstallation (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-YBZJYETY.js:11904:12)",
      "at async installPlugin (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-YBZJYETY.js:11953:12)",
      "at async loadAndPreparePlugin (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-Y74H4T62.js:62087:9)",
      "at async startAgent (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-Y74H4T62.js:62228:28)",
      "at async file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-Y74H4T62.js:62465:29",
      "at async Promise.allSettled (index 0)",
      "at async startAgents (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-Y74H4T62.js:62462:25)",
      "at async _Command.<anonymous> (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-Y74H4T62.js:62580:5)",
      "at async _Command.parseAsync (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/chunk-W4LNCUVN.js:1721:9)",
      "at async main (file:///Users/[username]/[project-path]/new-eliza/eliza/packages/cli/dist/index.js:95:3)"
    ]
    ```